### PR TITLE
Also emit end if reached_end

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ function papertrailStream(token, query, reverse) {
         r.push(evt);
       });
 
-      if (data.reached_beginning) {
+      if (data.reached_beginning || data.reached_end) {
         r.push(null);
       } else {
         setTimeout(fetch, 500);


### PR DESCRIPTION
It doesn't appear to be mentioned in the [docs](http://help.papertrailapp.com/kb/how-it-works/search-api/), but I've also seen a `reached_end: true` when papertrail finishes searching logs (using `min_time`).

This adds a check for that property so that papertrail-stream emits an `end` event and stops making more requests.
